### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/DabzTech/9f61caa2-e4ce-4083-b19f-9b40f8a74612/a488d683-fbb7-45ae-a593-77957f516d30/_apis/work/boardbadge/bb5059bb-9e68-4729-bcd3-51f2f419dc60)](https://dev.azure.com/DabzTech/9f61caa2-e4ce-4083-b19f-9b40f8a74612/_boards/board/t/a488d683-fbb7-45ae-a593-77957f516d30/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#115](https://dev.azure.com/DabzTech/9f61caa2-e4ce-4083-b19f-9b40f8a74612/_workitems/edit/115). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.